### PR TITLE
v 0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # CHANGELOG
 
 ## 0.4.2
-- Upgraded VkFFT from v1.3.3 to v1.3.4.
+- VkFFT upgraded from v1.3.3 to v1.3.4.
 
 ## 0.4.1
 - Fixes the GPU memory leak reported in [issue

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 0.4.2
+- Upgraded VkFFT from v1.3.3 to v1.3.4.
+
 ## 0.4.1
 - Fixes the GPU memory leak reported in [issue
   #62](https://github.com/elgw/deconwolf/issues/62).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## 0.4.2
 - VkFFT upgraded from v1.3.3 to v1.3.4.
+- Fixed an issue preventing anything than `--bq 0` to be used on
+  Windows (one array was not properly initialized to 0).
 
 ## 0.4.1
 - Fixes the GPU memory leak reported in [issue
@@ -179,19 +181,19 @@ Results when testing on the microtubules image shown below.
    commenting in/out the corresponding lines in the makefile.
  - Cleaned up the output of `dw --version`
 
-## v 0.2.7
+## 0.2.7
 - Converted a few minor code paths to execute in parallel by OpenMP
   directives.
 
-## v 0.2.6
+## 0.2.6
 - Using ISO 8601 in log files, e.g., `2023-02-14T11:14:14`.
 
-## v 0.2.5
+## 0.2.5
 - Added the **--xyz** option to **dw maxproj**, for creating max
   projections along the three axes and collecting them on a single 2D
   image.
 
-## v 0.2.4
+## 0.2.4
 - **dw --help** now shows the additional commands/modules available.
 - Reading 16-bit tif files with **TIFFReadEncodedStrip** instead of
   **TIFFReadRawStrip**. Some programs saves tiff files in other ways
@@ -202,13 +204,13 @@ Results when testing on the microtubules image shown below.
 - Setting the background level automatically to min(image) unless
   specified with **--bg**.
 
-## v 0.2.3
+## 0.2.3
 - Fixed some errors introduced in v 0.2.2, especially the **dw
   maxproj** was broken.
 - added the subcommand **dw merge**. To be used to merge single z-planes
   into a 3D volume.
 
-## v 0.2.2
+## 0.2.2
 - Can deconvolve using clFFT, when compiled with **OPENCL=1** two new
   methods appear, **--method shbcl** and **--shbcl2**, the first using
   clFFT only for the Fourier transforms, the latter using OpenCL for
@@ -216,12 +218,12 @@ Results when testing on the microtubules image shown below.
   is something to improve upon in future version, possibly by
   switching to vkFFT.
 
-## v 0.1.1
+## 0.1.1
 - Added experimental **dw imshift** for shifting images, also shift
   estimation using normalized cross correlation with **dw imshift
   --ref file.tif**. Might be extended to basic tiling etc.
 
-## v 0.1.0
+## 0.1.0
 - Implements the 'Scaled Heavy Ball'. More
 memory efficient than eve and about the same speed and image
 quality. Might become the default method.
@@ -241,20 +243,20 @@ iteration to a separate tsv file for easier plotting and analysis.
 - Three different stopping criteria: Relative error (default) Fixed
   number of iterations or at an absolute error.
 
-## v 0.0.26
+## 0.0.26
 - **dw maxproj** works with file that are not in the current folder.
 - Fixed **--iterdump** not always working.
 
-## v. 0.0.25
+## 0.0.25
 - Builds with cuFFT on Linux, use `make CUFFT=1 -B`, requires a CUDA
 compatible GPU and of course the cuFFT library installed.
 
-## v. 0.0.24
+## 0.0.24
 - Tested on CentOS, install both with make and meson.
 - Fixed a memory leak with the **--tilesize** option causing
 crashed sometimes.
 
-## v. 0.0.23
+## 0.0.23
 - Added 'meson.build' files in order for deconwolf to be built by
 [The Meson Build system](https://mesonbuild.com/), tested to work
 on both Ubuntu 21.10 and MacOS (on x86_64 hardware).
@@ -266,17 +268,17 @@ document.
 - Aborting if the number of threads is set < 1.
 - The algorithm is still unchanged since v 0.0.20.
 
-## v. 0.0.22
+## 0.0.22
 - Fixed double free-bug in tiling mode.
 
-## v. 0.0.21
+## 0.0.21
 - Updated documentation and man-pages based on markdown files
 for easier updating.
 - Provides `makefile-freebsd` for building on FreeBSD 13.0
 - Changed behavior when too few input arguments are given to
 only give a two-line message.
 
-## v. 0.0.20
+## 0.0.20
 - Changing acceleration technique to use
 'Exponential Vector Extrapolation' (EVE) described in Biggs PhD thesis.
 Deconvolved images get higher MSE but much lower I-div.
@@ -294,13 +296,13 @@ however that is not recommended.
 experimental option. 14 percent faster on a small test image, varied
 results on larger images.
 
-## v. 0.0.19
+## 0.0.19
 - Using lanczos5 instead of lanczos3 for the PSF generation. As a result
 GSL_EROUND is not raised for the test cases.
 - Faster PSF generation, using more symmetries.
 - dw_bw can now use more than one thread (wrongly disabled in v 0.0.18).
 
-## v. 0.0.18
+## 0.0.18
 - Provided install instructions for Windows 10.
 - Fixed some mismatching fftwf_malloc/fftwf_free where they were
 mixed up with malloc/free causing crashes on Windows.
@@ -309,7 +311,7 @@ building with cmake. It is also possible to cross compile for Windows
 on Linux although it takes some effort to collect the DLL files for the
 dependencies.
 
-## v. 0.0.17
+## 0.0.17
 - Fixed some bugs in the PSF generation code that did affect the accuracy
 of the pixels in the PSF.
 - Stared to use GSL for numerical integration. It remains to change the

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -118,7 +118,6 @@ The dependencies can get retrieved by vcpkg:
 ``` shell
 git clone https://github.com/microsoft/vcpkg
 .\vcpkg\bootstrap-vcpkg.bat
-.\vcpkg integrate install
 .\vcpkg\vcpkg.exe install fftw3[threads]
 .\vcpkg\vcpkg.exe install tiff
 .\vcpkg\vcpkg.exe install gsl
@@ -138,9 +137,17 @@ cmake "-DCMAKE_TOOLCHAIN_FILE=C:/YOUR/OWN/PATH/vcpkg/scripts/buildsystems/vcpkg.
 ```
 Important: Please use the correct path to `vcpkg.cmake`.
 
-Open visual studio and compile it from there. Don't forget to change the build type to release. 
+Open the visual studio solution and oo to Linker->Input->Additional
+dependencies and add:
 
-If you are a windows developer and reading this, please help us out get make this process smoother (if possible). 
+``` shell
+libomp.lib
+```
+
+Change the build type from debug to release and compile.
+
+If you are a windows developer and reading this, please help us out
+to make the build process smoother!
 
 ## FreeBSD
 - Use `gmake`, not `make`.

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# deconwolf v0.4.1
+# deconwolf v0.4.2
 
 **deconwolf**[^9] is a software for 3-D deconvolution of fluorescent wide-field
 images:

--- a/src/VkFFT/vkFFT/vkFFT.h
+++ b/src/VkFFT/vkFFT/vkFFT.h
@@ -107,6 +107,6 @@
 #include "vkFFT/vkFFT_AppManagement/vkFFT_DeleteApp.h"
 
 static inline int VkFFTGetVersion() {
-	return 10303; //X.XX.XX format
+	return 10304; //X.XX.XX format
 }
 #endif

--- a/src/dw_nuclei.c
+++ b/src/dw_nuclei.c
@@ -89,9 +89,9 @@ static void opts_free(opts * s)
  * than green set to 2. Everything else set to 0.
  * http://www.libpng.org/pub/png/libpng-manual.txt
  */
-fim_t * fim_png_read_green_red(char * fname)
+fimo * fim_png_read_green_red(char * fname)
 {
-    fim_t * F = NULL;
+    fimo * F = NULL;
 
     png_image image;
     memset(&image, 0, sizeof(image));
@@ -113,7 +113,7 @@ fim_t * fim_png_read_green_red(char * fname)
             size_t N = image.height;
             //printf("M=%zu, N=%zu image buffer %u b\n", M, N, PNG_IMAGE_SIZE(image));
 
-            F = malloc(sizeof(fim_t));
+            F = malloc(sizeof(fimo));
             assert(F != NULL);
             F->M = M;
             F->N = N;
@@ -291,7 +291,7 @@ static int float_arg_max(const float * v, size_t N)
     return argmax;
 }
 
-fim_t * get_reduction(opts * s, char * file)
+fimo * get_reduction(opts * s, char * file)
 {
 
 
@@ -325,7 +325,7 @@ fim_t * get_reduction(opts * s, char * file)
     {
         float * maxI = fim_maxproj(I, M, N, P);
         free(I);
-        fim_t * result = fim_image_from_array(maxI, M, N, 1);
+        fimo * result = fim_image_from_array(maxI, M, N, 1);
         free(maxI);
         return result;
     }
@@ -336,12 +336,12 @@ fim_t * get_reduction(opts * s, char * file)
         {
             printf("Finding focus\n"); fflush(stdout);
         }
-        fim_t * II = fim_image_from_array(I, M, N, P);
+        fimo * II = fim_image_from_array(I, M, N, P);
         free(I);
         float sigma = 1;
         float * gm = fim_focus_gm(II, sigma);
         int slice = float_arg_max(gm, II->P);
-        fim_t * result = malloc(sizeof(fim_t));
+        fimo * result = malloc(sizeof(fimo));
         assert(result != NULL);
         result->M = M;
         result->N = N;
@@ -349,7 +349,7 @@ fim_t * get_reduction(opts * s, char * file)
         result->V = malloc(M*N*sizeof(float));
         assert(result->V != NULL);
         memcpy(result->V, II->V+slice*M*N, M*N*sizeof(float));
-        fimt_free(II);
+        fimo_free(II);
         if(s->verbose > 0)
         {
             printf("Returning slice %d\n", slice); fflush(stdout);
@@ -387,7 +387,7 @@ void segment_image_rf(opts * s, PrfForest * F, char * file)
     printf("\n");
 
     /* Read the image */
-    fim_t * redu = get_reduction(s, file);
+    fimo * redu = get_reduction(s, file);
     assert(redu != NULL);
     printf("1\n"); fflush(stdout);
     /* Extract features */
@@ -453,7 +453,7 @@ void segment_image_rf(opts * s, PrfForest * F, char * file)
 
     fim_tiff_write_noscale(outfile, result, NULL,
                            redu->M, redu->N, 1);
-    fimt_free(redu);
+    fimo_free(redu);
     return;
 }
 
@@ -471,7 +471,7 @@ PrfForest * loop_training_data(opts * s, float * features_cm,
         }
 
         /* Read annotated image */
-        fim_t * anno = fim_png_read_green_red(s->anno_label);
+        fimo * anno = fim_png_read_green_red(s->anno_label);
         assert(anno != NULL);
 
         /* Append one columns for the annotations */
@@ -551,7 +551,7 @@ PrfForest * loop_training_data(opts * s, float * features_cm,
         }
         free(features_cma);
         free(features_cma_train);
-        fimt_free(anno);
+        fimo_free(anno);
         free(result);
     }
 
@@ -562,7 +562,7 @@ void random_forest_pipeline(opts * s, int argc, char ** argv)
 {
 
     /* Read raw image */
-    fim_t * anno_raw = get_reduction(s, s->anno_image);
+    fimo * anno_raw = get_reduction(s, s->anno_image);
 
     /* Extract features */
     ftab_t * features = fim_features_2d(anno_raw);

--- a/src/dw_psf.c
+++ b/src/dw_psf.c
@@ -545,14 +545,14 @@ static void downsample_integrate(float * A, float * B, int nA, int nB)
     free(K);
 }
 
-fim_t * gen_psf(opts * s, double lambda)
+fimo * gen_psf(opts * s, double lambda)
     {
     if(s->verbose > 2) { printf("Allocating for output\n"); fflush(stdout); }
 
     double optical_dx = s->optical.dx/s->oversampling;
 
     fim_tiff_init();
-    fim_t * PSF = fimt_zeros(s->M*s->oversampling, s->M*s->oversampling, s->P);
+    fimo * PSF = fimo_zeros(s->M*s->oversampling, s->M*s->oversampling, s->P);
 
     double Fs = 1/optical_dx;
     double Fn = Fs/2;
@@ -765,7 +765,7 @@ static float * conv2d_float(float * A, float * B,
 }
 
 
-static void pinhole_convolution(opts * s, fim_t * PSF)
+static void pinhole_convolution(opts * s, fimo * PSF)
 {
     /* Convolve PSF by a square filter. The specified pinhole is the
        diameter. */
@@ -840,7 +840,7 @@ static void dw_psf(opts * s)
         printf("Calculating emission PSF\n");
     }
 
-    fim_t * PSF = gen_psf(s, s->optical.lambda);
+    fimo * PSF = gen_psf(s, s->optical.lambda);
     if(s->optical.lambda2 != 0)
     {
         /* We will generate a PSF for a confocal microscope with
@@ -855,13 +855,13 @@ static void dw_psf(opts * s)
         {
             printf("Calculating excitation PSF\n");
         }
-        fim_t * PSF2 = gen_psf(s, s->optical.lambda2);
+        fimo * PSF2 = gen_psf(s, s->optical.lambda2);
         //printf("Multiplying PSFs\n");
-        for(size_t kk = 0; kk<fimt_nel(PSF); kk++)
+        for(size_t kk = 0; kk<fimo_nel(PSF); kk++)
         {
             PSF->V[kk] *= PSF2->V[kk];
         }
-        fimt_free(PSF2);
+        fimo_free(PSF2);
     }
 
 
@@ -869,8 +869,8 @@ static void dw_psf(opts * s)
     {
         printf("Writing to %s\n", s->outfile);
     }
-    float sum = fimt_sum(PSF);
-    fim_mult_scalar(PSF->V, fimt_nel(PSF), 1.0/sum);
+    float sum = fimo_sum(PSF);
+    fim_mult_scalar(PSF->V, fimo_nel(PSF), 1.0/sum);
 
     ttags * T = ttags_new();
     char * swstring = malloc(1024);
@@ -886,7 +886,7 @@ static void dw_psf(opts * s)
                          T,
                          PSF->M, PSF->N, PSF->P);
     ttags_free(&T);
-    fimt_free(PSF);
+    fimo_free(PSF);
 }
 
 int dw_psf_cli(int argc, char ** argv)

--- a/src/dw_psf_sted.c
+++ b/src/dw_psf_sted.c
@@ -289,9 +289,9 @@ static void argparsing(int argc, char ** argv, opts * s)
 
 
 
-static fim_t * gen_psf(opts * s)
+static fimo * gen_psf(opts * s)
 {
-    fim_t * PSF = fimt_zeros(s->M, s->M, s->P);
+    fimo * PSF = fimo_zeros(s->M, s->M, s->P);
     const double gamma = s->gamma;
     const double sigma = s->sigma;
 
@@ -357,10 +357,10 @@ static void dw_psf_sted(opts * s)
     {
         printf("Writing to %s\n", s->outfile);
     }
-    fim_t * PSF = gen_psf(s);
+    fimo * PSF = gen_psf(s);
 
-    float sum = fimt_sum(PSF);
-    fim_mult_scalar(PSF->V, fimt_nel(PSF), 1.0/sum);
+    float sum = fimo_sum(PSF);
+    fim_mult_scalar(PSF->V, fimo_nel(PSF), 1.0/sum);
 
     ttags * T = ttags_new();
     char * swstring = malloc(1024);
@@ -377,7 +377,7 @@ static void dw_psf_sted(opts * s)
                          T,
                          PSF->M, PSF->N, PSF->P);
     ttags_free(&T);
-    fimt_free(PSF);
+    fimo_free(PSF);
 }
 
 int dw_psf_sted_cli(int argc, char ** argv)

--- a/src/dw_render.c
+++ b/src/dw_render.c
@@ -212,7 +212,7 @@ static void argparsing(int argc, char ** argv, opts * s)
 }
 
 
-cairo_surface_t * fim_to_cairo_surface(fim_t * I,
+cairo_surface_t * fim_to_cairo_surface(fimo * I,
                                              float low, float high)
 {
     cairo_surface_t * result;
@@ -247,11 +247,11 @@ cairo_surface_t * fim_to_cairo_surface(fim_t * I,
     return result;
 }
 
-void render(opts * s, const fim_t * I, ftab_t * T)
+void render(opts * s, const fimo * I, ftab_t * T)
 {
     printf("Creating max projection\n");
     float * m = fim_maxproj(I->V, I->M, I->N, I->P);
-    fim_t * M = fim_image_from_array(m, I->M, I->N, 1);
+    fimo * M = fim_image_from_array(m, I->M, I->N, 1);
     free(m);
 
     if(s->lsigma > 0)
@@ -465,7 +465,7 @@ int dw_render(int argc, char ** argv)
 
     int64_t M = 0, N = 0, P = 0;
     float * A = fim_tiff_read(inFile, NULL, &M, &N, &P, s->verbose);
-    fim_t * I = fim_image_from_array(A, M, N, P);
+    fimo * I = fim_image_from_array(A, M, N, P);
     free(A);
 
     ftab_t * T = NULL;

--- a/src/dw_version.h
+++ b/src/dw_version.h
@@ -2,7 +2,7 @@
 
 #define DW_VERSION_MAJOR "0"
 #define DW_VERSION_MINOR "4"
-#define DW_VERSION_PATCH "1"
+#define DW_VERSION_PATCH "2"
 #define deconwolf_version DW_VERSION_MAJOR "." \
     DW_VERSION_MINOR "." \
     DW_VERSION_PATCH

--- a/src/fim.c
+++ b/src/fim.c
@@ -164,7 +164,7 @@ void fim_ianscombe(float * x, size_t n)
 }
 
 
-void fimt_free(fim_t * F)
+void fimo_free(fimo * F)
 {
     if(F != NULL)
     {
@@ -176,9 +176,9 @@ void fimt_free(fim_t * F)
 }
 
 
-fim_t * fim_wrap_array(float * V, size_t M, size_t N, size_t P)
+fimo * fim_wrap_array(float * V, size_t M, size_t N, size_t P)
 {
-    fim_t * I = malloc(sizeof(fim_t));
+    fimo * I = malloc(sizeof(fimo));
     assert(I != NULL);
     I->V = V;
     I->M = M;
@@ -187,9 +187,9 @@ fim_t * fim_wrap_array(float * V, size_t M, size_t N, size_t P)
     return I;
 }
 
-fim_t * fim_image_from_array(const float * restrict V, size_t M, size_t N, size_t P)
+fimo * fim_image_from_array(const float * restrict V, size_t M, size_t N, size_t P)
 {
-    fim_t * I = malloc(sizeof(fim_t));
+    fimo * I = malloc(sizeof(fimo));
     assert(I != NULL);
     I->V = fim_malloc(M*N*P*sizeof(float));
 
@@ -417,7 +417,7 @@ void fim_minus(float * restrict  A,
     return;
 }
 
-void fimt_add(fim_t * A, const fim_t * B)
+void fimo_add(fimo * A, const fimo * B)
 {
     assert(A->M == B->M);
     assert(A->N == B->N);
@@ -717,9 +717,9 @@ float * fim_copy(const float * restrict V, const size_t N)
     return C;
 }
 
-fim_t * fimt_copy(const fim_t * restrict F)
+fimo * fimo_copy(const fimo * restrict F)
 {
-    fim_t * C = malloc(sizeof(fim_t));
+    fimo * C = malloc(sizeof(fimo));
     assert(C != NULL);
     C->V = fim_copy(F->V, F->M*F->N*F->P);
     C->M = F->M;
@@ -736,11 +736,11 @@ float * fim_zeros(const size_t N)
     return A;
 }
 
-fim_t * fimt_zeros(const size_t M, const size_t N, const size_t P)
+fimo * fimo_zeros(const size_t M, const size_t N, const size_t P)
 // Allocate and return an array of N floats
 {
     size_t n = M*N*P;
-    fim_t * F = malloc(sizeof(fim_t));
+    fimo * F = malloc(sizeof(fimo));
     assert(F != NULL);
     F->V = fim_malloc(n*sizeof(float));
 
@@ -751,14 +751,14 @@ fim_t * fimt_zeros(const size_t M, const size_t N, const size_t P)
     return F;
 }
 
-size_t fimt_nel(fim_t * F)
+size_t fimo_nel(fimo * F)
 {
     return F->M*F->N*F->P;
 }
 
-float fimt_sum(fim_t * F)
+float fimo_sum(fimo * F)
 {
-    return fim_sum(F->V, fimt_nel(F));
+    return fim_sum(F->V, fimo_nel(F));
 }
 
 float * fim_constant(const size_t N, const float value)
@@ -1335,10 +1335,10 @@ void fim_LoG_ut()
     }
 
 
-    fim_t * T = fim_image_from_array(V, M, N, P);
-    fim_t * S1 = fim_shiftdim(T);
-    fim_t * S2 = fim_shiftdim(S1);
-    fim_t * S3 = fim_shiftdim(S2);
+    fimo * T = fim_image_from_array(V, M, N, P);
+    fimo * S1 = fim_shiftdim(T);
+    fimo * S2 = fim_shiftdim(S1);
+    fimo * S3 = fim_shiftdim(S2);
     for(size_t kk = 0; kk<M*N*P; kk++)
     {
         if(T->V[kk] != S3->V[kk])
@@ -1348,14 +1348,14 @@ void fim_LoG_ut()
             exit(EXIT_FAILURE);
         }
     }
-    fimt_free(T);
+    fimo_free(T);
     T = NULL;
     assert(S1->V != S2->V);
-    fimt_free(S1);
+    fimo_free(S1);
     S1 = NULL;
-    fimt_free(S2);
+    fimo_free(S2);
     S2 = NULL;
-    fimt_free(S3);
+    fimo_free(S3);
 
 
     for(size_t kk = 0; kk<M*N*P; kk++)
@@ -1478,7 +1478,7 @@ static float fim_interp_periodic(const float * V, int64_t nV,
     return V[stride*(idx % nV)];
 }
 
-void fimt_conv1_x(fim_t * V, fim_t * K, fim_boundary_condition bc)
+void fimo_conv1_x(fimo * V, fimo * K, fim_boundary_condition bc)
 {
 
 #pragma omp parallel
@@ -1494,7 +1494,7 @@ void fimt_conv1_x(fim_t * V, fim_t * K, fim_boundary_condition bc)
                 fim_conv1(line, V->M,
                           1, // stride
                           K->V,
-                          fimt_nel(K),
+                          fimo_nel(K),
                           B,
                           bc);
             }
@@ -2348,10 +2348,10 @@ float * fim_maxproj_ref(const float * V, size_t M, size_t N, size_t P)
     return Pr;
 }
 
-fim_t * fimt_maxproj(const fim_t * F)
+fimo * fimo_maxproj(const fimo * F)
 {
     float * _M = fim_maxproj(F->V, F->M, F->N, F->P);
-    fim_t * M = malloc(sizeof(fim_t));
+    fimo * M = malloc(sizeof(fimo));
     assert(M != NULL);
     M->V = _M;
     M->M = F->M;
@@ -3168,18 +3168,18 @@ float * conv1_3(const float * restrict V, size_t M, size_t N, size_t P,
     const int dim = 0;
     const int norm = 0;
 
-    fim_t * F = fim_image_from_array(V, M, N, P);
+    fimo * F = fim_image_from_array(V, M, N, P);
 
     fim_convn1(F->V, F->M, F->N, F->P, K1, nK1, dim, norm);
-    fim_t * F2 = fim_shiftdim(F);
+    fimo * F2 = fim_shiftdim(F);
     fim_free(F->V);
     fim_free(F);
     fim_convn1(F2->V, F2->M, F2->N, F2->P, K2, nK2, dim, norm);
-    fim_t * F3 = fim_shiftdim(F2);
+    fimo * F3 = fim_shiftdim(F2);
     fim_free(F2->V);
     fim_free(F2);
     fim_convn1(F3->V, F3->M, F3->N, F3->P, K3, nK3, dim, norm);
-    fim_t * F4 = fim_shiftdim(F3);
+    fimo * F4 = fim_shiftdim(F3);
     fim_free(F3->V);
     fim_free(F3);
     float * out = F4->V;
@@ -3297,61 +3297,61 @@ float * fim_LoG_S2(const float * V0, const size_t M, const size_t N, const size_
     /* Lateral filters */
     size_t nlG = 0;
     float * _lG = gaussian_kernel(sigmaxy, &nlG);
-    fim_t * lG = fim_wrap_array(_lG, nlG, 1, 1);
+    fimo * lG = fim_wrap_array(_lG, nlG, 1, 1);
     size_t nl2;
     float * _l2 = gaussian_kernel_d2(sigmaxy, &nl2);
     flip_sign(_l2, nl2);
-    fim_t * l2 = fim_wrap_array(_l2, nl2, 1, 1);
+    fimo * l2 = fim_wrap_array(_l2, nl2, 1, 1);
 
     /* 2D */
     if(P == 1)
     {
-        assert(fimt_nel(lG) > 1);
-        assert(fimt_nel(l2) > 1);
+        assert(fimo_nel(lG) > 1);
+        assert(fimo_nel(l2) > 1);
 
         printf("2D path\n");
         /** Gaussian, Laplacian **/
-        fim_t * GI = fim_image_from_array(V0, M, N, P);
-        fimt_conv1_x(GI, lG, bc);
-        fim_t * GL = fim_shiftdim2(GI);
+        fimo * GI = fim_image_from_array(V0, M, N, P);
+        fimo_conv1_x(GI, lG, bc);
+        fimo * GL = fim_shiftdim2(GI);
         assert(GL->P == 1);
         fim_free(GI);
-        fimt_conv1_x(GL, l2, bc);
+        fimo_conv1_x(GL, l2, bc);
 
         /** Laplacian, Gaussian **/
-        fim_t * LI = fim_image_from_array(V0, M, N, P);
-        fimt_conv1_x(LI, l2, bc);
+        fimo * LI = fim_image_from_array(V0, M, N, P);
+        fimo_conv1_x(LI, l2, bc);
         assert(LI->P == 1);
-        fim_t * LG = fim_shiftdim2(LI);
+        fimo * LG = fim_shiftdim2(LI);
         fim_free(LI);
-        fimt_conv1_x(LG, lG, bc);
+        fimo_conv1_x(LG, lG, bc);
 
         /* Free filters */
-        fimt_free(lG);
-        fimt_free(l2);
+        fimo_free(lG);
+        fimo_free(l2);
 
         /* Add together filter responses */
-        fim_t * LoG = GL;
+        fimo * LoG = GL;
         GL = NULL;
-        fimt_add(LoG, LG);
-        fimt_free(LG);
+        fimo_add(LoG, LG);
+        fimo_free(LG);
 
         /* Shift back */
-        fim_t * result = fim_shiftdim2(LoG);
+        fimo * result = fim_shiftdim2(LoG);
 
-        fimt_free(LoG);
+        fimo_free(LoG);
         /* And we are done */
 
         float * pLoG = result->V;
 
         result->V = NULL;
-        fimt_free(result);
+        fimo_free(result);
         return pLoG;
     }
 
     /* Axial filters */
-    fim_t * aG = NULL;
-    fim_t * a2 = NULL;
+    fimo * aG = NULL;
+    fimo * a2 = NULL;
 
     {
         size_t naG = 0;
@@ -3367,57 +3367,57 @@ float * fim_LoG_S2(const float * V0, const size_t M, const size_t N, const size_
     if(P > 1)
     {
         /** First dimension -> GII, LII */
-        fim_t * GII = fim_image_from_array(V0, M, N, P);
-        fimt_conv1_x(GII, lG, bc);
+        fimo * GII = fim_image_from_array(V0, M, N, P);
+        fimo_conv1_x(GII, lG, bc);
 
-        fim_t * LII = fim_image_from_array(V0, M, N, P);
-        fimt_conv1_x(LII, l2, bc);
+        fimo * LII = fim_image_from_array(V0, M, N, P);
+        fimo_conv1_x(LII, l2, bc);
 
         /** 2nd dimension -> GGI, GLI, LGI */
         /* Prepare buffers */
-        fim_t * GGI = fim_shiftdim(GII);
-        fimt_free(GII);
-        fim_t * GLI = fimt_copy(GGI);
-        fim_t * LGI = fim_shiftdim(LII);
-        fimt_free(LII);
+        fimo * GGI = fim_shiftdim(GII);
+        fimo_free(GII);
+        fimo * GLI = fimo_copy(GGI);
+        fimo * LGI = fim_shiftdim(LII);
+        fimo_free(LII);
         /* Apply filters */
-        fimt_conv1_x(GGI, lG, bc);
-        fimt_conv1_x(GLI, l2, bc);
-        fimt_conv1_x(LGI, lG, bc);
+        fimo_conv1_x(GGI, lG, bc);
+        fimo_conv1_x(GLI, l2, bc);
+        fimo_conv1_x(LGI, lG, bc);
 
         /** 3rd dimension -> GGL, GLG, LGG */
-        fim_t * GGL = fim_shiftdim(GGI);
-        fimt_free(GGI);
-        fim_t * GLG = fim_shiftdim(GLI);
-        fimt_free(GLI);
-        fim_t * LGG = fim_shiftdim(LGI);
-        fimt_free(LGI);
+        fimo * GGL = fim_shiftdim(GGI);
+        fimo_free(GGI);
+        fimo * GLG = fim_shiftdim(GLI);
+        fimo_free(GLI);
+        fimo * LGG = fim_shiftdim(LGI);
+        fimo_free(LGI);
 
-        fimt_conv1_x(GGL, a2, bc);
-        fimt_conv1_x(GLG, aG, bc);
-        fimt_conv1_x(LGG, aG, bc);
+        fimo_conv1_x(GGL, a2, bc);
+        fimo_conv1_x(GLG, aG, bc);
+        fimo_conv1_x(LGG, aG, bc);
 
         /* Free the filters */
-        fimt_free(lG);
-        fimt_free(l2);
-        fimt_free(aG);
-        fimt_free(a2);
+        fimo_free(lG);
+        fimo_free(l2);
+        fimo_free(aG);
+        fimo_free(a2);
 
         /** Merge results */
-        fim_t * LoG = GGL;
+        fimo * LoG = GGL;
         GGL = NULL;
-        fimt_add(LoG, GLG);
-        fimt_free(GLG);
-        fimt_add(LoG, LGG);
-        fimt_free(LGG);
+        fimo_add(LoG, GLG);
+        fimo_free(GLG);
+        fimo_add(LoG, LGG);
+        fimo_free(LGG);
 
         /** Shift back to original shape */
-        fim_t * result = fim_shiftdim(LoG);
-        fimt_free(LoG);
+        fimo * result = fim_shiftdim(LoG);
+        fimo_free(LoG);
 
         float * pLoG = result->V;
         result->V = NULL;
-        fimt_free(result);
+        fimo_free(result);
         return pLoG;
     }
 
@@ -3426,12 +3426,12 @@ float * fim_LoG_S2(const float * V0, const size_t M, const size_t N, const size_
 
 
 /* Parital derivative in dimension dim */
-fim_t * fimt_partial(const fim_t * F, const int dim, const float sigma)
+fimo * fimo_partial(const fimo * F, const int dim, const float sigma)
 {
 
     if(F->P != 1)
     {
-        fprintf(stderr, "fimt_partial only supports 2D images (please fix me)\n");
+        fprintf(stderr, "fimo_partial only supports 2D images (please fix me)\n");
         exit(EXIT_FAILURE);
     }
 
@@ -3441,7 +3441,7 @@ fim_t * fimt_partial(const fim_t * F, const int dim, const float sigma)
     float * D1 = gaussian_kernel_d1(sigma, &nD1);
 
 
-    fim_t * D = fimt_copy(F);
+    fimo * D = fimo_copy(F);
     if(dim == 0)
     {
         fim_convn1(D->V, D->M, D->N, D->P, D1, nD1, 0, 0);
@@ -3459,7 +3459,7 @@ fim_t * fimt_partial(const fim_t * F, const int dim, const float sigma)
         return D;
     }
 
-    fprintf(stderr, "Something went wrong in fimt_partial dim=%d\n", dim);
+    fprintf(stderr, "Something went wrong in fimo_partial dim=%d\n", dim);
     exit(EXIT_FAILURE);
 
 
@@ -3557,7 +3557,7 @@ float * fim_LoG(const float * V, const size_t M, const size_t N, const size_t P,
     return LoG;
 }
 
-double * fim_get_line_double(fim_t * I,
+double * fim_get_line_double(fimo * I,
                              int x, int y, int z,
                              int dim, int nPix)
 {
@@ -3601,7 +3601,7 @@ double * fim_get_line_double(fim_t * I,
     return L;
 }
 
-fim_t * fim_shiftdim2(const fim_t * restrict I)
+fimo * fim_shiftdim2(const fimo * restrict I)
 {
     const float * V = I->V;
     const size_t M = I->M;
@@ -3609,7 +3609,7 @@ fim_t * fim_shiftdim2(const fim_t * restrict I)
     const size_t P = I->P;
     assert(P == 1);
     /* Output image */
-    fim_t * O = malloc(sizeof(fim_t));
+    fimo * O = malloc(sizeof(fimo));
     assert(O != NULL);
     O->V = fim_malloc(M*N*P*sizeof(float));
     O->M = N;
@@ -3646,7 +3646,7 @@ fim_t * fim_shiftdim2(const fim_t * restrict I)
     return O;
 }
 
-fim_t * fim_shiftdim(const fim_t * restrict I)
+fimo * fim_shiftdim(const fimo * restrict I)
 {
     const float * V = I->V;
     const size_t M = I->M;
@@ -3654,7 +3654,7 @@ fim_t * fim_shiftdim(const fim_t * restrict I)
     const size_t P = I->P;
 
     /* Output image */
-    fim_t * O = malloc(sizeof(fim_t));
+    fimo * O = malloc(sizeof(fimo));
     assert(O != NULL);
     O->V = fim_malloc(M*N*P*sizeof(float));
 
@@ -3713,10 +3713,10 @@ static float eig_sym_22_2nd(float a, float b, float c)
 
 static float total_gm(const float * I0, size_t M, size_t N, float sigma)
 {
-    fim_t * I = fim_image_from_array(I0, M, N, 1);
-    fim_t * dx = fimt_partial(I, 0, sigma);
-    fim_t * dy = fimt_partial(I, 1, sigma);
-    fimt_free(I);
+    fimo * I = fim_image_from_array(I0, M, N, 1);
+    fimo * dx = fimo_partial(I, 0, sigma);
+    fimo * dy = fimo_partial(I, 1, sigma);
+    fimo_free(I);
 
     double gm = 0;
     for(size_t kk = 0; kk<M*N; kk++)
@@ -3724,12 +3724,12 @@ static float total_gm(const float * I0, size_t M, size_t N, float sigma)
         gm += sqrt( pow(dx->V[kk], 2) + pow(dy->V[kk], 2));
     }
 
-    fimt_free(dx);
-    fimt_free(dy);
+    fimo_free(dx);
+    fimo_free(dy);
     return (float) gm;
 }
 
-float * fim_focus_gm(const fim_t * I, float sigma)
+float * fim_focus_gm(const fimo * I, float sigma)
 {
     float * gm = malloc(I->P*sizeof(float));
     assert(gm != NULL);
@@ -3740,7 +3740,7 @@ float * fim_focus_gm(const fim_t * I, float sigma)
     return gm;
 }
 
-ftab_t * fim_features_2d(const fim_t * fI)
+ftab_t * fim_features_2d(const fimo * fI)
 {
     int debug = 0; /* Write out the features  */
     const char debug_image_name[] = "fim_features_2d_debug_image.tif";
@@ -3789,15 +3789,15 @@ ftab_t * fim_features_2d(const fim_t * fI)
         float sigma = sigmas[ss];
         printf("%f ", sigma); fflush(stdout);
 
-        fim_t * G = fimt_copy(fI);
+        fimo * G = fimo_copy(fI);
 
         fim_gsmooth(G->V, M, N, P, sigma);
 
-        fim_t * dx = fimt_partial(fI, 0, sigma);
-        fim_t * dy = fimt_partial(fI, 1, sigma);
-        fim_t * ddx = fimt_partial(dx, 0, sigma);
-        fim_t * ddy = fimt_partial(dy, 1, sigma);
-        fim_t * dxdy = fimt_partial(dx, 1, sigma);
+        fimo * dx = fimo_partial(fI, 0, sigma);
+        fimo * dy = fimo_partial(fI, 1, sigma);
+        fimo * ddx = fimo_partial(dx, 0, sigma);
+        fimo * ddy = fimo_partial(dy, 1, sigma);
+        fimo * dxdy = fimo_partial(dx, 1, sigma);
 
         float * value = G->V;
         /* Gaussian, 1f */
@@ -3878,12 +3878,12 @@ ftab_t * fim_features_2d(const fim_t * fI)
         debug == 1 ? memcpy(debug_image + M*N*col, value, M*N*sizeof(float)) : 0;
         sprintf(sbuff, "s%.1f_HE_EV_2", sigma);
         ftab_set_colname(T, col++, sbuff);
-        fimt_free(dx);
-        fimt_free(dy);
-        fimt_free(ddx);
-        fimt_free(ddy);
-        fimt_free(dxdy);
-        fimt_free(G);
+        fimo_free(dx);
+        fimo_free(dy);
+        fimo_free(ddx);
+        fimo_free(ddy);
+        fimo_free(dxdy);
+        fimo_free(G);
     }
     free(sbuff); /* Free string buffer */
     printf("\n");
@@ -3915,7 +3915,7 @@ void fim_features_2d_ut()
 
     float * V = fim_tiff_read(file, NULL, &M, &N, &P, 0);
     printf("%s is %" PRId64 " %" PRId64 " %" PRId64 " image\n", file, M, N, P);
-    fim_t * I = malloc(sizeof(fim_t));
+    fimo * I = malloc(sizeof(fimo));
     assert(I != NULL);
     I->V = V;
     I->M = M;
@@ -3925,7 +3925,7 @@ void fim_features_2d_ut()
     T->nrow = 10;
     ftab_print(stdout, T, ",");
     ftab_free(T);
-    fimt_free(I);
+    fimo_free(I);
 }
 
 
@@ -4178,9 +4178,9 @@ void fim_ut()
     myfftw_stop();
 }
 
-fim_t * fimt_transpose(const fim_t * restrict A)
+fimo * fimo_transpose(const fimo * restrict A)
 {
-    fim_t * B = fimt_copy(A);
+    fimo * B = fimo_copy(A);
     size_t M = A->M;
     size_t N = A->N;
     size_t P = A->P;
@@ -4203,12 +4203,12 @@ fim_t * fimt_transpose(const fim_t * restrict A)
     return B;
 }
 
-int fimt_tiff_write(const fim_t * I, const char * fName)
+int fimo_tiff_write(const fimo * I, const char * fName)
 {
     return fim_tiff_write_float(fName, I->V, NULL, I->M, I->N, I->P);
 }
 
-void fimt_blit_2D(fim_t * A, const fim_t * B, size_t x0, size_t y0)
+void fimo_blit_2D(fimo * A, const fimo * B, size_t x0, size_t y0)
 {
     assert(A != NULL);
     assert(B != NULL);

--- a/src/fim.c
+++ b/src/fim.c
@@ -733,7 +733,10 @@ fimo * fimo_copy(const fimo * restrict F)
 float * fim_zeros(const size_t N)
 // Allocate and return an array of N floats
 {
+    assert(N > 0);
     float * A = fim_malloc(N*sizeof(float));
+    assert(A[0] == 0);
+    assert(A[N-1] == 0)
     return A;
 }
 

--- a/src/fim.c
+++ b/src/fim.c
@@ -80,7 +80,9 @@ void * __attribute__((__aligned__(FIM_ALIGNMENT))) fim_malloc(size_t nbytes)
 void * fim_malloc(size_t nbytes)
 {
 #ifdef WINDOWS
-    return _aligned_malloc(nbytes, FIM_ALIGNMENT);
+    void * p = _aligned_malloc(nbytes, FIM_ALIGNMENT);
+    memset(p, 0, nbytes);
+    return p;
 #else
     void * p;
     if(posix_memalign(&p, FIM_ALIGNMENT, nbytes))
@@ -732,7 +734,6 @@ float * fim_zeros(const size_t N)
 // Allocate and return an array of N floats
 {
     float * A = fim_malloc(N*sizeof(float));
-    //memset(A, 0, N*sizeof(float));
     return A;
 }
 

--- a/src/fim.c
+++ b/src/fim.c
@@ -736,7 +736,7 @@ float * fim_zeros(const size_t N)
     assert(N > 0);
     float * A = fim_malloc(N*sizeof(float));
     assert(A[0] == 0);
-    assert(A[N-1] == 0)
+    assert(A[N-1] == 0);
     return A;
 }
 

--- a/src/fim.h
+++ b/src/fim.h
@@ -41,8 +41,7 @@
 #endif
 
 
-/* fim : operations on 3D floating point images
- * all allocations are done with fftw3f_malloc (for alignment)
+/* fim : operations on 3D Floating point IMages
  *
  * functions ending with `_ref` are reference implementations to be compared
  * tweaked or alternative versions.
@@ -51,12 +50,17 @@
 /* Set verbosity level, default = 0 */
 void fim_set_verbose(int);
 
+#define MAGIC_FIMO 0xFIM35555DEC04301UL
+
 typedef struct{
+    #ifndef NDEBUG
+    uint64_t magic; // TODO: set to MAGIC_FIMO
+    #endif
     float * V;
     size_t M;
     size_t N;
     size_t P;
-} fim_t;
+} fimo;
 
 /* Alignment of fim_malloc and fim_realloc, in bytes */
 
@@ -67,7 +71,7 @@ typedef struct{
 
 /** @brief Aligned allocations
  *
- * Use for images only, not for fim_t etc.
+ * Use for images only, not for fimo etc.
  * make sure to deallocate with fim_free.
  *
  * Calls exit if the allocation fails.
@@ -89,71 +93,71 @@ void * __attribute__((__aligned__(FIM_ALIGNMENT))) fim_realloc(void * p, size_t 
  */
 void fim_free(void * p);
 
-/** @brief Delete/free a fim_t object.
+/** @brief Delete/free a fimo object.
  *
- * Frees all resources associated with the fim_t object.
- * as well as the fim_t object itself.
+ * Frees all resources associated with the fimo object.
+ * as well as the fimo object itself.
  */
-void fimt_free(fim_t *);
+void fimo_free(fimo *);
 
-fim_t * fimt_zeros(size_t M, size_t N, size_t P);
+fimo * fimo_zeros(size_t M, size_t N, size_t P);
 
 /** @brief Create a new object with a copy of V
  *
  * Note: Both V and the returned object has to be freed eventually
  *
- * @return A newly allocated fim_t which contains a copy of V
+ * @return A newly allocated fimo which contains a copy of V
  *
  */
-fim_t * fim_image_from_array(const float * restrict V,
+fimo * fim_image_from_array(const float * restrict V,
                              size_t M, size_t N, size_t P);
 
-/** @brief Wrap an array by a fim_t object
+/** @brief Wrap an array by a fimo object
  *
  * This creates a pointer to the data, not a copy.
  *
 */
-fim_t * fim_wrap_array(float * V, size_t M, size_t N, size_t P);
+fimo * fim_wrap_array(float * V, size_t M, size_t N, size_t P);
 
 /* Return a new copy */
-fim_t * fimt_copy(const fim_t * );
+fimo * fimo_copy(const fimo * );
 
 /* Extract a line centered at (x, y, z) with nPix pixels along dimension dim */
-double * fim_get_line_double(fim_t * Im,
+double * fim_get_line_double(fimo * Im,
                              int x, int y, int z,
                              int dim, int nPix);
 
 /* Similar to MATLABs shiftfim, [M,N,P] -> [N,P,M] */
-fim_t * fim_shiftdim(const fim_t * restrict );
+fimo * fim_shiftdim(const fimo * restrict );
 
 /* Similar to MATLABs shiftfim, [M,N] -> [N,M] */
-fim_t * fim_shiftdim2(const fim_t * restrict );
+fimo * fim_shiftdim2(const fimo * restrict );
 
 
 /* [M, N, P] -> [N, M, P] */
-fim_t * fimt_transpose(const fim_t * restrict);
+fimo * fimo_transpose(const fimo * restrict);
 
 /* Partial derivative along dimension dim */
-fim_t * fimt_partial(const fim_t *, int dim, float sigma);
+fimo * fimo_partial(const fimo *, int dim, float sigma);
 
 /* Features for 2D image classification
  * the input image should be 2D.
  * Uses similar features a Ilastic
  * Returns one row per pixel
  */
-ftab_t * fim_features_2d(const fim_t *);
+ftab_t * fim_features_2d(const fimo *);
 
 /* Return a I->P long vector with the integral
  * gradient magnitude per slice in I */
-float * fim_focus_gm(const fim_t * image, float sigma);
+float * fim_focus_gm(const fimo * image, float sigma);
 
 /* Number of elements */
-size_t fimt_nel(fim_t * );
+size_t fimo_nel(fimo * );
 /* Sum of elements */
-float fimt_sum(fim_t * );
+float fimo_sum(fimo * );
 
 /*
- * API not using fim_t
+ * API not using fimo
  */
 
 float fim_min(const float * restrict A, size_t N);
@@ -164,7 +168,7 @@ float fim_sum(const float * restrict A, size_t N);
 /* Standard deviation, normalizing by (N-1) */
 float fim_std(const float * V, size_t N);
 
-fim_t * fimt_maxproj(const fim_t * Im);
+fimo * fimo_maxproj(const fimo * Im);
 
 float * fim_maxproj(const float * A, size_t M, size_t N, size_t P);
 
@@ -193,7 +197,7 @@ void fim_add(float * restrict A,
              size_t N);
 
 /* A[kk] += B[kk] */
-void fimt_add(fim_t * A, const fim_t * B);
+void fimo_add(fimo * A, const fimo * B);
 
 void fim_invert(float * restrict A, const size_t N);
 
@@ -490,11 +494,11 @@ float * fim_LoG_S2(const float * V0, const size_t M, const size_t N, const size_
                    const float sigmaxy, const float sigmaz);
 
 /* Simple interface to write 2D or 3D images without any meta data */
-int fimt_tiff_write(const fim_t * Im, const char * fName);
+int fimo_tiff_write(const fimo * Im, const char * fName);
 
 
 /* Insert into B into A, with upper left corner at x0, y0 */
-void fimt_blit_2D(fim_t * A, const fim_t * B, size_t x0, size_t y0);
+void fimo_blit_2D(fimo * A, const fimo * B, size_t x0, size_t y0);
 
 /**  Anscombe transform and inverse.
  *

--- a/src/fim_tiff.c
+++ b/src/fim_tiff.c
@@ -1062,11 +1062,11 @@ int fim_tiff_get_size(const char * fname,
     return 0;
 }
 
-fim_t * fimt_tiff_read(const char * fName)
+fimo * fimo_tiff_read(const char * fName)
 {
     int64_t M, N, P;
     float * V = fim_tiff_read(fName, NULL, &M, &N, &P, 0);
-    fim_t * I = malloc(sizeof(fim_t));
+    fimo * I = malloc(sizeof(fimo));
     assert(I != NULL);
     I->V = V;
     I->M = M;
@@ -1630,25 +1630,25 @@ char * tiff_is_supported(TIFF * tiff)
 
 int fim_tiff_maxproj_XYZ(const char * in, const char * out)
 {
-    fim_t * I = fimt_tiff_read(in);
+    fimo * I = fimo_tiff_read(in);
     //printf("[%zu, %zu, %zu]\n", I->M, I->N, I->P);
 
     /* Along Z */
-    fim_t * max_xy = fimt_maxproj(I);
+    fimo * max_xy = fimo_maxproj(I);
 
     /* Along X */
-    fim_t * Iyz = fim_shiftdim(I);
-    fim_t * _max_yz = fimt_maxproj(Iyz);
-    fim_t * max_yz = fimt_transpose(_max_yz);
-    fimt_free(_max_yz);
+    fimo * Iyz = fim_shiftdim(I);
+    fimo * _max_yz = fimo_maxproj(Iyz);
+    fimo * max_yz = fimo_transpose(_max_yz);
+    fimo_free(_max_yz);
 
     /* Along Y */
-    fim_t * Ixz = fim_shiftdim(Iyz);
-    fimt_free(Iyz);
-    fim_t * _max_xz = fimt_maxproj(Ixz);
-    fim_t * max_xz = fimt_transpose(_max_xz);
-    fimt_free(_max_xz);
-    fimt_free(Ixz);
+    fimo * Ixz = fim_shiftdim(Iyz);
+    fimo_free(Iyz);
+    fimo * _max_xz = fimo_maxproj(Ixz);
+    fimo * max_xz = fimo_transpose(_max_xz);
+    fimo_free(_max_xz);
+    fimo_free(Ixz);
 
 
     // TODO: Scale according to pixel size?
@@ -1656,9 +1656,9 @@ int fim_tiff_maxproj_XYZ(const char * in, const char * out)
     /* Concatenation */
     size_t MM = I->M + I->P;
     size_t NN = I->N + I->P;
-    fimt_free(I);
+    fimo_free(I);
 
-    fim_t * xview = malloc(sizeof(fim_t));
+    fimo * xview = malloc(sizeof(fimo));
     assert(xview != NULL);
     xview->M = MM;
     xview->N = NN;
@@ -1672,21 +1672,21 @@ int fim_tiff_maxproj_XYZ(const char * in, const char * out)
         printf("[%zu, %zu, %zu] XZ\n", max_xz->M, max_xz->N, max_xz->P);
         printf("[%zu, %zu, %zu] YZ\n", max_yz->M, max_yz->N, max_yz->P);
 
-        fimt_tiff_write(max_xy, "max_xy.tif");
-        fimt_tiff_write(max_xz, "max_xz.tif");
-        fimt_tiff_write(max_yz, "max_yz.tif");
+        fimo_tiff_write(max_xy, "max_xy.tif");
+        fimo_tiff_write(max_xz, "max_xz.tif");
+        fimo_tiff_write(max_yz, "max_yz.tif");
     }
 
-    fimt_blit_2D(xview, max_xy, 0, 0);
-    fimt_blit_2D(xview, max_xz, 0, max_xy->N);
-    fimt_blit_2D(xview, max_yz, max_xy->M, 0);
+    fimo_blit_2D(xview, max_xy, 0, 0);
+    fimo_blit_2D(xview, max_xz, 0, max_xy->N);
+    fimo_blit_2D(xview, max_yz, max_xy->M, 0);
 
-    fimt_free(max_xy);
-    fimt_free(max_xz);
-    fimt_free(max_yz);
+    fimo_free(max_xy);
+    fimo_free(max_xz);
+    fimo_free(max_yz);
 
-    fimt_tiff_write(xview, out);
-    fimt_free(xview);
+    fimo_tiff_write(xview, out);
+    fimo_free(xview);
 
     return EXIT_SUCCESS;
 }

--- a/src/method_shb.c
+++ b/src/method_shb.c
@@ -156,7 +156,7 @@ float * deconvolve_shb(float * restrict im,
         {
             if(P1[kk] > sigma)
             {
-                P1[kk] = 1/P1[kk];
+                P1[kk] = 1.0/P1[kk];
             } else {
                 P1[kk] = 0;
             }


### PR DESCRIPTION
- VkFFT upgraded from v1.3.3 to v1.3.4.
- Fixed an issue preventing anything than `--bq 0` to be used on
  Windows (one array was not properly initialized to 0).
