### PR TITLE
Add modifications for installation with spack

### DIFF
--- a/src/dw_imshift.c
+++ b/src/dw_imshift.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <assert.h>
 #include <getopt.h>
 #include <math.h>

--- a/src/dw_tiff_merge.c
+++ b/src/dw_tiff_merge.c
@@ -1,3 +1,4 @@
+#include <inttypes.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/fft.c
+++ b/src/fft.c
@@ -14,6 +14,7 @@
  *    along with this program.  If not, see <https://www.gnu.org/licenses/>.
  */
 
+#include <inttypes.h>
 #include <assert.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/src/trafo/CMakeLists.txt
+++ b/src/trafo/CMakeLists.txt
@@ -18,8 +18,8 @@ endif()
 message(STATUS "Build type: ${CMAKE_BUILD_TYPE}")
 
 # Don't install to /usr/local/ use /usr/
-set( CMAKE_INSTALL_PREFIX
-  /usr )
+#set( CMAKE_INSTALL_PREFIX
+#  /usr )
 
 add_library(trafo SHARED
   src/entropy.c


### PR DESCRIPTION
Hi! these are a couple of changes I had to make to install the software using spack. I am not a C programmer, so let me know if I did something wrong :)

I have added the inttypes.h includes due to this error while running cmake:

```
/share/apps/spack/generate-binaries/spack-stage/service.spack01/spack-stage-deconwolf-0.4.4-yolqzmxydqinupnfavs7baaqt47dmlrg/spack-src/src/fft.c:842:25: error: expected ')' before 'PRId64'
  842 |         printf("Size: %" PRId64 ", time %e\n", kk+from, t[kk]);
      |                         ^~~~~~~
      |                         )
/share/apps/spack/generate-binaries/spack-stage/service.spack01/spack-stage-deconwolf-0.4.4-yolqzmxydqinupnfavs7baaqt47dmlrg/spack-src/src/fft.c:842:23: warning: spurious trailing '%' in format [-Wformat=]
  842 |         printf("Size: %" PRId64 ", time %e\n", kk+from, t[kk]);
      |                       ^
/share/apps/spack/generate-binaries/spack-stage/service.spack01/spack-stage-deconwolf-0.4.4-yolqzmxydqinupnfavs7baaqt47dmlrg/spack-src/src/fft.c:852:25: error: expected ')' before 'PRId64'
  852 |         printf("Size: %" PRId64 ", time %e\n", kk+from, t[kk]);
      |                         ^~~~~~~
      |                         )
/share/apps/spack/generate-binaries/spack-stage/service.spack01/spack-stage-deconwolf-0.4.4-yolqzmxydqinupnfavs7baaqt47dmlrg/spack-src/src/fft.c:852:23: warning: spurious trailing '%' in format [-Wformat=]
  852 |         printf("Size: %" PRId64 ", time %e\n", kk+from, t[kk]);
      |                       ^
make[2]: *** [CMakeFiles/dw_bw.dir/build.make:121: CMakeFiles/dw_bw.dir/src/fft.c.o] Error 1
make[2]: *** Waiting for unfinished jobs....
```

Also I removed the CMAKE_INSTALL_PREFIX since spack installs software in custom locations and handles this variable automatically.
